### PR TITLE
Fix GitHub Pages build: supply Supabase env vars

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,9 @@ jobs:
       - run: npm ci
 
       - run: npm run build
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.VITE_SUPABASE_PUBLISHABLE_KEY }}
 
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
The auth integration reads `VITE_SUPABASE_URL` and `VITE_SUPABASE_PUBLISHABLE_KEY` at build time (`import.meta.env`). The Pages workflow never provided them, so Vite inlined `undefined` — the build passed but the deployed site errors at runtime. This passes both into the build step from repo Actions secrets.

**Required before this helps:** add `VITE_SUPABASE_URL` and `VITE_SUPABASE_PUBLISHABLE_KEY` as Actions secrets on this repo, then re-run the deploy.