### PR TITLE
Deploy the staging branch via its own Vercel Deploy Hook

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -1,11 +1,11 @@
 name: Trigger Vercel deploy
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
   workflow_dispatch:
 
 concurrency:
-  group: vercel-deploy
+  group: vercel-deploy-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -13,11 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fire Vercel Deploy Hook
-        run: |
-          if [ -z "${VERCEL_DEPLOY_HOOK_URL}" ]; then
-            echo "VERCEL_DEPLOY_HOOK_URL secret is not set." >&2
-            exit 1
-          fi
-          curl -fsS -X POST "${VERCEL_DEPLOY_HOOK_URL}"
         env:
           VERCEL_DEPLOY_HOOK_URL: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
+          VERCEL_STAGING_DEPLOY_HOOK_URL: ${{ secrets.VERCEL_STAGING_DEPLOY_HOOK_URL }}
+        run: |
+          case "${GITHUB_REF_NAME}" in
+            main) HOOK="${VERCEL_DEPLOY_HOOK_URL}" ;;
+            staging) HOOK="${VERCEL_STAGING_DEPLOY_HOOK_URL}" ;;
+            *) echo "No deploy hook configured for branch ${GITHUB_REF_NAME}." >&2; exit 1 ;;
+          esac
+          if [ -z "${HOOK}" ]; then
+            echo "Deploy hook URL for ${GITHUB_REF_NAME} is not set." >&2
+            exit 1
+          fi
+          curl -fsS -X POST "${HOOK}"


### PR DESCRIPTION
Follow-up to #22 (main deploys). Extends the deploy workflow to also fire on pushes to `staging`, choosing the Deploy Hook per branch:
- `main` → `VERCEL_DEPLOY_HOOK_URL`
- `staging` → `VERCEL_STAGING_DEPLOY_HOOK_URL`

Concurrency is now scoped per ref so a staging deploy doesn't cancel an in-flight main deploy.

**Setup required:**
1. Create a Vercel **Custom Environment** (e.g. "Staging") with branch tracking set to `staging`, and add its staging-scoped env vars.
2. Create a **Deploy Hook** bound to the `staging` branch.
3. Add its URL as the `VERCEL_STAGING_DEPLOY_HOOK_URL` repository secret.
4. Create the `staging` branch.