### PR TITLE
Honor VITE_BASE_PATH in the staging custom environment

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -48,11 +48,17 @@ const inlineHeroicons = () => {
 
 export default defineConfig(({mode}) => {
   const env = loadEnv(mode, ".", "")
-  const isVercelNonProd =
-    env.VERCEL === "1" && env.VERCEL_ENV !== "production"
+  // Only genuine standalone preview deploys are served at the domain root.
+  // Production AND the staging custom environment are served under the portal
+  // subpath (/hydroviewer/), so both must honor VITE_BASE_PATH. VERCEL_ENV is
+  // "preview" for a custom environment, so key off VERCEL_TARGET_ENV, which
+  // carries the custom environment name ("staging").
+  const targetEnv = env.VERCEL_TARGET_ENV || env.VERCEL_ENV
+  const servedAtRoot =
+    env.VERCEL === "1" && targetEnv !== "production" && targetEnv !== "staging"
 
   return {
-    base: isVercelNonProd ? "/" : env.VITE_BASE_PATH || "/",
+    base: servedAtRoot ? "/" : env.VITE_BASE_PATH || "/",
     plugins: [tailwindcss(), inlineHeroicons(), injectAppVersionDate()],
     worker: {
       format: "es", // Use ES modules in workers


### PR DESCRIPTION
The `staging` custom environment reports `VERCEL_ENV=preview`, so the existing non-prod check forces `base:"/"` — which breaks assets when staging is served under the portal's `/hydroviewer/` subpath.

This keys off `VERCEL_TARGET_ENV` (which carries the custom-environment name) and treats `staging` like production for the base path. **Production, standalone previews, GitHub Pages, and local dev are unchanged** (verified by the condition: only Vercel deploys whose target is neither `production` nor `staging` still serve at root).

Required for the staging deploy to render correctly under `apps-staging.geoglows.org/hydroviewer/`.