### PR TITLE
Consume @geoglows/geoglows-auth from GitHub Packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@geoglows:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "rfs-hydroviewer",
       "version": "1.0.0",
       "dependencies": {
-        "@aquaveo/geoglows-auth": "^1.4.0",
         "@arcgis/core": "^4.34.8",
         "@arcgis/map-components": "^4.34.9",
         "@esri/calcite-components": "^3.3.3",
+        "@geoglows/geoglows-auth": "^1.4.0",
         "heroicons": "^2.2.0",
         "plotly.js": "^3.3.1",
         "zarrita": "^0.5.4"
@@ -53,21 +53,6 @@
         "seedrandom": "^3.0.5",
         "svg-arc-to-cubic-bezier": "^3.2.0",
         "tslib": "^2.2.0"
-      }
-    },
-    "node_modules/@aquaveo/geoglows-auth": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@aquaveo/geoglows-auth/-/geoglows-auth-1.4.0.tgz",
-      "integrity": "sha512-IE0WN59BUCoRRX9QAycikNIClcq3yJLRYoDGfttkxpZNP3aByqtw25czSq63S8mgxf8iUn6VE7iqM18LN19RXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/supabase-js": "^2.50.0",
-        "oidc-client-ts": "^3.5.0"
-      },
-      "peerDependencies": {
-        "lucide-react": ">=0.400.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0"
       }
     },
     "node_modules/@arcgis/core": {
@@ -298,6 +283,21 @@
       "resolved": "https://registry.npmjs.org/@foliojs-fork/restructure/-/restructure-2.0.2.tgz",
       "integrity": "sha512-59SgoZ3EXbkfSX7b63tsou/SDGzwUEK6MuB5sKqgVK1/XE0fxmpsOb9DQI8LXW3KfGnAjImCGhhEb7uPPAUVNA==",
       "license": "MIT"
+    },
+    "node_modules/@geoglows/geoglows-auth": {
+      "version": "1.6.1",
+      "resolved": "https://npm.pkg.github.com/download/@geoglows/geoglows-auth/1.6.1/d412fcf71382d8bbc8d1727fc5e6d410b870bc37",
+      "integrity": "sha512-LONrqRV9bEpprmN0izTzd95p4HH2nzVKu2lNmqmagFlbGlgVnKi+uwpx9DvxKluDsi05HPpR3Fo/QR0iFfHZ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/supabase-js": "^2.50.0",
+        "oidc-client-ts": "^3.5.0"
+      },
+      "peerDependencies": {
+        "lucide-react": ">=0.400.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
     },
     "node_modules/@interactjs/types": {
       "version": "1.10.27",
@@ -739,9 +739,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -759,9 +756,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -779,9 +773,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -799,9 +790,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -819,9 +807,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -839,9 +824,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1170,9 +1152,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1190,9 +1169,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1210,9 +1186,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1230,9 +1203,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4359,9 +4329,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4383,9 +4350,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4407,9 +4371,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4431,9 +4392,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@aquaveo/geoglows-auth": "^1.4.0",
+    "@geoglows/geoglows-auth": "^1.4.0",
     "@arcgis/core": "^4.34.8",
     "@arcgis/map-components": "^4.34.9",
     "@esri/calcite-components": "^3.3.3",

--- a/src/auth-bootstrap.js
+++ b/src/auth-bootstrap.js
@@ -19,8 +19,8 @@ import {
   createSupabaseAuthAdapter,
   mountSignInModal,
   renderAuthAction,
-} from "@aquaveo/geoglows-auth/core"
-import "@aquaveo/geoglows-auth/core/sign-in.css"
+} from "@geoglows/geoglows-auth/core"
+import "@geoglows/geoglows-auth/core/sign-in.css"
 
 const SIGN_IN_REQUESTED_EVENT = "geoglows:sign-in-requested"
 
@@ -119,7 +119,7 @@ const tabHasRecoveryUrl = (() => {
   }
   if (hasCode && hasRecovery) {
     console.error(
-      "PKCE recovery flow is not supported in @aquaveo/geoglows-auth 1.2.x.",
+      "PKCE recovery flow is not supported in @geoglows/geoglows-auth 1.2.x.",
     )
     signInModal.open({view: "recoveryError"})
     return true


### PR DESCRIPTION
The auth library moved to the geoglows org and is published to **GitHub Packages** as `@geoglows/geoglows-auth` (previously `@aquaveo/geoglows-auth` on npm).

- Dependency + imports switched to the new scope.
- Adds `.npmrc` pointing `@geoglows` at `npm.pkg.github.com`, auth via `${NODE_AUTH_TOKEN}`.
- Lockfile refreshed against the published `1.6.1`.

**Install now needs a `read:packages` token as `NODE_AUTH_TOKEN`** — already set on this project's Vercel envs (production/preview/staging); local devs need it in their shell/`~/.npmrc`.