### PR TITLE
Geoglows auth from source

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,6 @@ permissions:
   contents: read
   pages: write
   id-token: write
-  packages: read
 
 concurrency:
   group: pages
@@ -27,8 +26,6 @@ jobs:
           cache: npm
 
       - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - run: npm run build
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-@geoglows:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@arcgis/core": "^4.34.8",
         "@arcgis/map-components": "^4.34.9",
         "@esri/calcite-components": "^3.3.3",
-        "@geoglows/geoglows-auth": "^1.7.0",
+        "@geoglows/geoglows-auth": "github:geoglows/geoglows-auth#v1.7.2",
         "heroicons": "^2.2.0",
         "plotly.js": "^3.3.1",
         "zarrita": "^0.5.4"
@@ -285,9 +285,8 @@
       "license": "MIT"
     },
     "node_modules/@geoglows/geoglows-auth": {
-      "version": "1.7.0",
-      "resolved": "https://npm.pkg.github.com/download/@geoglows/geoglows-auth/1.7.0/475f7d3842eb772ccf470096156ac732436ea9c7",
-      "integrity": "sha512-jPDQnpr1cp8nqbItvkTjm3zjp9ekXXldIswtAbCpa2VOBWikiAFDWzWWUdQ0VSjzAF3GYTcEtd+eLMBIhn+j1A==",
+      "version": "1.7.2",
+      "resolved": "git+ssh://git@github.com/geoglows/geoglows-auth.git#23879f7fac8ae6f420be26087f8fd5a27b5725a3",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.50.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@geoglows/geoglows-auth": "^1.7.0",
+    "@geoglows/geoglows-auth": "github:geoglows/geoglows-auth#v1.7.2",
     "@arcgis/core": "^4.34.8",
     "@arcgis/map-components": "^4.34.9",
     "@esri/calcite-components": "^3.3.3",


### PR DESCRIPTION
This pull request updates the project's dependency management and deployment workflow by switching the `@geoglows/geoglows-auth` package to a GitHub repository reference, removing private npm registry configuration, and cleaning up related authentication steps in the deployment process. These changes simplify package installation and deployment by no longer requiring a private npm token.

**Dependency management updates:**

* Changed the `@geoglows/geoglows-auth` dependency in `package.json` to use a direct GitHub repository reference (`github:geoglows/geoglows-auth#v1.7.2`) instead of a version from the npm registry.
* Removed the `.npmrc` file configuration for the private GitHub npm registry and authentication token, as it is no longer needed.

**Deployment workflow simplification:**

* Removed the `packages: read` permission from the GitHub Actions workflow, since private package access is no longer required. (`.github/workflows/deploy.yml`)
* Removed the `NODE_AUTH_TOKEN` environment variable from the `npm ci` step in the deployment workflow, further simplifying authentication. (`.github/workflows/deploy.yml`)